### PR TITLE
Add perl-Time-HiRes to required packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class ccs_mrtg (
   String[1] $interface = 'auto',
   Optional[String[1]] $daq_interface = undef,
 ) {
-  ensure_packages(['net-snmp', 'mrtg', 'pwgen', 'patch', 'freeipmi'])
+  ensure_packages(['net-snmp', 'mrtg', 'pwgen', 'patch', 'freeipmi', 'perl-Time-HiRes'])
 
   ## Get the community from snmpd.conf, or generate a new random one.
   $snmp_community = $facts['snmp_community']


### PR DESCRIPTION
Explicitly needed on rhel9, likely due to a bug with the mrtg rpm.